### PR TITLE
feat(Search n Result): Searchbar data passing in Search and Result page

### DIFF
--- a/Coco/Common/Components/InputTextField/CocoInputTextField.swift
+++ b/Coco/Common/Components/InputTextField/CocoInputTextField.swift
@@ -17,8 +17,9 @@ struct CocoInputTextField: View {
     private let leadingIcon: UIImage?
     private let trailingIcon: ImageHandler?
     private let placeholder: String?
+    
+    let isFocused: FocusState<Bool>.Binding
 
-    @FocusState private var isFocused: Bool
     private let onFocusedAction: ((Bool) -> Void)?
 
     init(
@@ -27,7 +28,8 @@ struct CocoInputTextField: View {
         trailingIcon: ImageHandler? = nil,
         placeholder: String?,
         shouldInterceptFocus: Bool = false,
-        onFocusedAction: ((Bool) -> Void)? = nil
+        onFocusedAction: ((Bool) -> Void)? = nil,
+        isFocused: FocusState<Bool>.Binding
     ) {
         self.leadingIcon = leadingIcon
         _currentTypedText = currentTypedText
@@ -35,6 +37,7 @@ struct CocoInputTextField: View {
         self.placeholder = placeholder
         self.shouldInterceptFocus = shouldInterceptFocus
         self.onFocusedAction = onFocusedAction
+        self.isFocused = isFocused // The binding is now stored directly.
     }
 
     var body: some View {
@@ -52,12 +55,11 @@ struct CocoInputTextField: View {
                 onFocusedAction: onFocusedAction
             )
         )
-        .focused($isFocused)
-        .onChange(of: isFocused) { isFocused in
-            onFocusedAction?(isFocused)
+        .focused(isFocused)
+        .onChange(of: isFocused.wrappedValue) { newValue in
+            onFocusedAction?(newValue)
         }
         .font(.jakartaSans(forTextStyle: .body, weight: .medium))
         .frame(height: kInputHeight)
-
     }
 }

--- a/Coco/Pages/Home/FormSchedule/HomeFormScheduleViewModel.swift
+++ b/Coco/Pages/Home/FormSchedule/HomeFormScheduleViewModel.swift
@@ -102,6 +102,12 @@ extension HomeFormScheduleViewModel: HomeSearchBarViewModelDelegate {
 
         }
     }
+    
+    func homeSearchBarDidTapForNavigation() {
+        // This method is called when isTypeAble is false, which is the case for calendarInputViewModel
+        // So, we should trigger the calendar option here.
+        actionDelegate?.showCalendarOption()
+    }
 }
 
 private extension HomeFormScheduleViewModel {

--- a/Coco/Pages/Home/HomeCoordinator.swift
+++ b/Coco/Pages/Home/HomeCoordinator.swift
@@ -52,7 +52,8 @@ final class HomeCoordinator: BaseCoordinator {
                     isTypeAble: true,
                     delegate: nil
                 ),
-                latestSearches: latestSearches
+                latestSearches: latestSearches,
+                lastSearchQuery: self.lastAppliedSearchQuery
             )
             searchViewModel.delegate = self
             let searchViewController: SearchViewController = SearchViewController(viewModel: searchViewModel)
@@ -62,13 +63,14 @@ final class HomeCoordinator: BaseCoordinator {
 
     private let input: Input
     private let homeViewModel: HomeViewModelProtocol?
+    private var lastAppliedSearchQuery: String?
 }
 
-extension HomeCoordinator: HomeViewModelNavigationDelegate {
-    func notifyHomeDidSelectActivity() {
-
-    }
-}
+//extension HomeCoordinator: HomeViewModelNavigationDelegate {
+//    func notifyHomeDidSelectActivity() {
+//
+//    }
+//}
 
 extension HomeCoordinator: HomeFormScheduleViewModelDelegate {
     func notifyFormScheduleDidNavigateToCheckout(with response: CreateBookingResponse) {
@@ -111,6 +113,7 @@ extension HomeCoordinator: ActivityDetailNavigationDelegate {
 
 extension HomeCoordinator: SearchViewModelDelegate {
     func searchViewModel(didApplySearch query: String) {
+        self.lastAppliedSearchQuery = query
         guard let homeViewModel = homeViewModel else { return }
         let activities = homeViewModel.getActivities()
         

--- a/Coco/Pages/Home/HomeViewController.swift
+++ b/Coco/Pages/Home/HomeViewController.swift
@@ -95,7 +95,7 @@ extension HomeViewController: HomeViewModelAction {
         coordinator.start()
     }
     
-    func searchDidTap(latestSearches: [HomeSearchSearchLocationData], currentQuery: String) {
+    func navigateToSearch(latestSearches: [HomeSearchSearchLocationData], currentQuery: String) {
         guard let navigationController else { return }
         let coordinator: HomeCoordinator = HomeCoordinator(
             input: .init(

--- a/Coco/Pages/Home/HomeViewModel.swift
+++ b/Coco/Pages/Home/HomeViewModel.swift
@@ -258,12 +258,16 @@ extension HomeViewModel: HomeSearchBarViewModelDelegate {
     func notifyHomeSearchBarDidTap(isTypeAble: Bool, viewModel: HomeSearchBarViewModel) {
         guard !isTypeAble else { return }
         
-        // TODO: Change with real data
-        actionDelegate?.searchDidTap(
+        // This method is now deprecated. Use homeSearchBarDidTapForNavigation instead.
+        // The logic here is moved to homeSearchBarDidTapForNavigation.
+    }
+    
+    func homeSearchBarDidTapForNavigation() {
+        actionDelegate?.navigateToSearch(
             latestSearches: [
-                .init(id: 1, name: "Kepulauan Seribu"),
-                .init(id: 2, name: "Nusa Penida"),
-                .init(id: 3, name: "Gili Island, Indonesia"),
+                HomeSearchSearchLocationData(id: 1, name: "Kepulauan Seribu"),
+                HomeSearchSearchLocationData(id: 2, name: "Nusa Penida"),
+                HomeSearchSearchLocationData(id: 3, name: "Gili Island, Indonesia"),
             ],
             currentQuery: searchBarViewModel.currentTypedText
         )

--- a/Coco/Pages/Home/HomeViewModelContract.swift
+++ b/Coco/Pages/Home/HomeViewModelContract.swift
@@ -21,7 +21,7 @@ protocol HomeViewModelAction: AnyObject {
     func toggleLoadingView(isShown: Bool, after: CGFloat)
     func activityDidSelect(data: ActivityDetailDataModel)
     
-    func searchDidTap(latestSearches: [HomeSearchSearchLocationData], currentQuery: String)
+    func navigateToSearch(latestSearches: [HomeSearchSearchLocationData], currentQuery: String)
     func openFilterTray(_ viewModel: HomeSearchFilterTrayViewModel)
     func dismissTray()
     func showEmptyState(_ show: Bool)

--- a/Coco/Pages/Home/Result/ResultViewController.swift
+++ b/Coco/Pages/Home/Result/ResultViewController.swift
@@ -62,4 +62,9 @@ extension ResultViewController: ResultViewModelAction {
         thisView.addSearchBarView(from: searchBarViewController.view)
         searchBarViewController.didMove(toParent: self)
     }
+    
+    func notifySearchBarTappedForNavigation() {
+        navigationController?.popViewController(animated: true)
+    }
 }
+

--- a/Coco/Pages/Home/Result/ResultViewModel.swift
+++ b/Coco/Pages/Home/Result/ResultViewModel.swift
@@ -32,8 +32,18 @@ class ResultViewModel: ResultViewModelProtocol {
             currentTypedText: query,
             trailingIcon: (image: CocoIcon.icFilterIcon.image, didTap: {}),
             isTypeAble: false,
-            delegate: nil
+            delegate: self
         )
         actionDelegate?.constructNavBar(viewModel: searchBarViewModel)
+    }
+}
+
+extension ResultViewModel: HomeSearchBarViewModelDelegate {
+    func notifyHomeSearchBarDidTap(isTypeAble: Bool, viewModel: HomeSearchBarViewModel) {
+        // Not used for this specific case
+    }
+    
+    func homeSearchBarDidTapForNavigation() {
+        actionDelegate?.notifySearchBarTappedForNavigation()
     }
 }

--- a/Coco/Pages/Home/Result/ResultViewModelContract.swift
+++ b/Coco/Pages/Home/Result/ResultViewModelContract.swift
@@ -16,4 +16,5 @@ protocol ResultViewModelProtocol: AnyObject {
 protocol ResultViewModelAction: AnyObject {
     func constructCollectionView(viewModel: some HomeCollectionViewModelProtocol)
     func constructNavBar(viewModel: HomeSearchBarViewModel)
+    func notifySearchBarTappedForNavigation()
 }

--- a/Coco/Pages/Home/Search/SearchViewController.swift
+++ b/Coco/Pages/Home/Search/SearchViewController.swift
@@ -52,6 +52,13 @@ class SearchViewController: UIViewController {
         ])
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if let lastSearchQuery = viewModel.lastSearchQuery {
+            viewModel.searchBarViewModel.currentTypedText = lastSearchQuery
+        }
+    }
+
     @objc func backButtonTapped() {
         navigationController?.popViewController(animated: true)
     }

--- a/Coco/Pages/Home/Search/SearchViewModel.swift
+++ b/Coco/Pages/Home/Search/SearchViewModel.swift
@@ -22,21 +22,28 @@ final class SearchViewModel: ObservableObject {
     @Published var searchBarViewModel: HomeSearchBarViewModel
     @Published var popularLocations: [HomeSearchSearchLocationData] = []
     @Published var latestSearches: [HomeSearchSearchLocationData]
+    @Published var lastSearchQuery: String?
     
     weak var delegate: SearchViewModelDelegate?
     
     init(
         searchBarViewModel: HomeSearchBarViewModel,
         latestSearches: [HomeSearchSearchLocationData] = [],
-        activityFetcher: ActivityFetcherProtocol = ActivityFetcher()
+        activityFetcher: ActivityFetcherProtocol = ActivityFetcher(),
+        lastSearchQuery: String? = nil
     ) {
         self.searchBarViewModel = searchBarViewModel
         self.activityFetcher = activityFetcher
         self.latestSearches = latestSearches
+        self.lastSearchQuery = lastSearchQuery
+        if let lastSearchQuery = lastSearchQuery {
+            self.searchBarViewModel.currentTypedText = lastSearchQuery
+        }
     }
     
     @MainActor
     func onAppear() {
+        searchBarViewModel.isSearchBarFocused = true
         activityFetcher.fetchTopDestination() { [weak self] result in
             guard let self else { return }
             switch result {
@@ -53,6 +60,7 @@ final class SearchViewModel: ObservableObject {
     private let activityFetcher: ActivityFetcherProtocol
 
     func applySearch(query: String) {
+        self.lastSearchQuery = query
         delegate?.searchViewModel(didApplySearch: query)
     }
 

--- a/Coco/Pages/Home/SearchBar/HomeSearchBarView.swift
+++ b/Coco/Pages/Home/SearchBar/HomeSearchBarView.swift
@@ -1,4 +1,3 @@
-//
 //  HomeSearchBarView.swift
 //  Coco
 //
@@ -10,6 +9,8 @@ import SwiftUI
 
 struct HomeSearchBarView: View {
     @ObservedObject var viewModel: HomeSearchBarViewModel
+    
+    @FocusState private var isFocused: Bool
 
     var body: some View {
         CocoInputTextField(
@@ -18,8 +19,15 @@ struct HomeSearchBarView: View {
             trailingIcon: viewModel.trailingIcon,
             placeholder: viewModel.placeholderText,
             shouldInterceptFocus: !viewModel.isTypeAble,
-            onFocusedAction: viewModel.onTextFieldFocusDidChange(to:)
+            onFocusedAction: viewModel.onTextFieldFocusDidChange(to:),
+            isFocused: $isFocused
         )
+        .onChange(of: isFocused) { newValue in
+            viewModel.isSearchBarFocused = newValue
+        }
+        .onChange(of: viewModel.isSearchBarFocused) { newValue in
+            isFocused = newValue
+        }
     }
 }
 

--- a/Coco/Pages/Home/SearchBar/HomeSearchBarViewModel.swift
+++ b/Coco/Pages/Home/SearchBar/HomeSearchBarViewModel.swift
@@ -11,6 +11,7 @@ import Combine
 
 protocol HomeSearchBarViewModelDelegate: AnyObject {
     func notifyHomeSearchBarDidTap(isTypeAble: Bool, viewModel: HomeSearchBarViewModel)
+    func homeSearchBarDidTapForNavigation()
 }
 
 final class HomeSearchBarViewModel: ObservableObject {
@@ -18,6 +19,7 @@ final class HomeSearchBarViewModel: ObservableObject {
 
     @Published var currentTypedText: String = ""
     @Published var trailingIcon: ImageHandler?
+    @Published var isSearchBarFocused: Bool = false
 
     let leadingIcon: UIImage?
     let isTypeAble: Bool
@@ -47,7 +49,11 @@ final class HomeSearchBarViewModel: ObservableObject {
 
     func onTextFieldFocusDidChange(to newFocus: Bool) {
         guard newFocus else { return }
-        delegate?.notifyHomeSearchBarDidTap(isTypeAble: isTypeAble, viewModel: self)
+        if !isTypeAble {
+            delegate?.homeSearchBarDidTapForNavigation()
+        } else {
+            delegate?.notifyHomeSearchBarDidTap(isTypeAble: isTypeAble, viewModel: self)
+        }
     }
 
     private func observeSearchText() {


### PR DESCRIPTION
- Search bar in Search Page now holds the previous query when returning from Result Page
- Auto focus on search bar after navigating

- Replaced `searchDidTap()` to `navigateToSearch()`
- Moved CocoInputTextField's FocusState to HomeSearchBarView